### PR TITLE
Update ReLU description: Don't call it a one-to-one operation. 

### DIFF
--- a/src/article/Article.svelte
+++ b/src/article/Article.svelte
@@ -178,7 +178,7 @@
     	Neural networks are extremely prevalent in modern technology&mdash;because they are so accurate!  The highest performing CNNs today consist of an absurd amount of layers, which are able to learn more and more features.  Part of the reason these groundbreaking CNNs are able to achieve such <a href="https://arxiv.org/pdf/1512.03385.pdf" title="ResNet">tremendous accuracies</a> is because of their non-linearity.  ReLU applies much-needed non-linearity into the model.  Non-linearity is necessary to produce non-linear decision boundaries, so that the output cannot be written as a linear combination of the inputs.  If a non-linear activation function was not present, deep CNN architectures would devolve into a single, equivalent convolutional layer, which would not perform nearly as well.  The ReLU activation function is specifically used as a non-linear activation function, as opposed to other non-linear functions such as <em>Sigmoid</em> because it has been <a href="https://arxiv.org/pdf/1906.01975.pdf" title="See page 29">empirically observed</a> that CNNs using ReLU are faster to train than their counterparts.
     </p>
     <p>
-  	The ReLU activation function is a one-to-one mathematical operation: {reluEquation}
+  	The ReLU activation function is an elementwise mathematical operation: {reluEquation}
     </p>
     <div class="figure">
     <img src="PUBLIC_URL/assets/figures/relu_graph.png" alt="relu graph" width="30%" height="30%"/>


### PR DESCRIPTION
I found it confusing to call ReLU "a one-to-one mathematical operation".  
In mathematical context, the ReLU is a relation $f:  \mathbb{R} \to \mathbb{R}^{+}$, which is not one-to-one. 

I suppose that intention was to convey that the ReLU maps every distinct element of the input to a number. 

The proposed formulation is "The ReLU activation function is **an elementwise** mathematical operation".  